### PR TITLE
Replace decommissioned code.google.com reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "testdata"]
 	path = testdata
-	url = https://code.google.com/r/jtuley-keyczar-testdata/
+	url = https://github.com/jbtule/keyczar-testdata/


### PR DESCRIPTION
code.google.com has been turned down -- and the https://code.google.com/r/jtuley-keyczar-testdata/ repo is no longer accessible.

That repo was migrated to https://github.com/jbtule/keyczar-testdata

Update this project's .gitmodules to reference the new github endpoint for the test data.